### PR TITLE
Refactor UI components to replace 'show_copy_button' with 'buttons' f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ or
 
 `run.sh` は `uv run multimodal_retriever.py` をバックグラウンドで起動し、標準出力と標準エラーを `output.log` に出力します。PID は `multimodal_retriever.pid` に保存されます。既に起動中の場合、`start` はエラー終了し、`restart` を使ってください。
 
+`output.log` の先頭に `nohup: ignoring input` と出ることがあります。これは `nohup` が標準入力を切り離した際の情報メッセージであり、起動失敗の原因ではありません。
+
 アプリケーションは`.env`ファイルの設定に従って、ローカルまたはリモートモードで起動します。Gradio の一時ディレクトリはカレントディレクトリ配下の `temp/gradio` に作成されます。
 
 ## UIの主な使い方

--- a/app/ui/components.py
+++ b/app/ui/components.py
@@ -169,7 +169,7 @@ class UIComponents:
                     label="画像ファイル名",
                     placeholder="画像ファイル名を入力してください（例: image001.jpg）",
                     interactive=True,
-                    show_copy_button=True
+                    buttons=["copy"]
                 )
                 
                 # ボタン群
@@ -199,7 +199,7 @@ class UIComponents:
                                 label="",
                                 lines=12,
                                 interactive=False,
-                                show_copy_button=True,
+                                buttons=["copy"],
                                 placeholder="キャプションがここに表示されます"
                             )
                             
@@ -210,7 +210,7 @@ class UIComponents:
                                 label="",
                                 lines=12,
                                 interactive=True,
-                                show_copy_button=True,
+                                buttons=["copy"],
                                 placeholder="キャプションを編集してください"
                             )
                     
@@ -268,7 +268,7 @@ class UIComponents:
                                     label="現在のプロンプト",
                                     lines=8,
                                     interactive=False,
-                                    show_copy_button=True,
+                                    buttons=["copy"],
                                     value=initial_prompt,
                                     placeholder="選択されたプロンプトがここに表示されます"
                                 )
@@ -430,9 +430,9 @@ class UIComponents:
             with gr.Row():        
                 with gr.Column():
                     with gr.Row():
-                        filename_text = gr.Textbox(show_label=True, label="ファイル名", interactive=False, container=True, show_copy_button=True)
-                        image_id_text = gr.Textbox(show_label=True, label="イメージID", interactive=False, container=True, show_copy_button=True)
-                        similarity_text = gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True)
+                        filename_text = gr.Textbox(show_label=True, label="ファイル名", interactive=False, container=True, buttons=["copy"])
+                        image_id_text = gr.Textbox(show_label=True, label="イメージID", interactive=False, container=True, buttons=["copy"])
+                        similarity_text = gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"])
                     with gr.Row():
                         caption_text = gr.Textbox(
                             show_label=True,
@@ -440,7 +440,7 @@ class UIComponents:
                             interactive=False,
                             lines=10,
                             container=True,
-                            show_copy_button=True,
+                            buttons=["copy"],
                             placeholder="キャプションがここに表示されます"
                         )
                 
@@ -456,7 +456,7 @@ class UIComponents:
                     show_label=True,
                     interactive=False,
                     container=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     scale=4,
                     lines=2
                 )
@@ -467,7 +467,7 @@ class UIComponents:
                 label="全文検索：形態素解析結果",
                 show_label=True,
                 container=True,
-                show_copy_button=True,
+                buttons=["copy"],
                 visible=False,
                 elem_id="morphological_analysis"
             )
@@ -480,7 +480,7 @@ class UIComponents:
                     show_label=True,
                     interactive=False,
                     lines=8,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     container=True
                 )
                 
@@ -519,7 +519,7 @@ class UIComponents:
                     show_label=True,
                     interactive=False,
                     container=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT,
                     scale=1
                 )
@@ -539,7 +539,7 @@ class UIComponents:
                     placeholder="回答生成で使用する質問文を入力してください",
                     interactive=True,
                     lines=3,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     container=True,
                     scale=3
                 )
@@ -557,7 +557,7 @@ class UIComponents:
                     interactive=False,
                     lines=10,
                     container=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     placeholder="回答がここに表示されます"
                 )
             with gr.Row():
@@ -580,7 +580,7 @@ class UIComponents:
                     interactive=False,
                     lines=3,
                     container=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     visible=False,
                     placeholder="VLMによるフィルタリングと並べ替えの選別理由がここに表示されます"
                 )
@@ -626,7 +626,7 @@ class UIComponents:
                     placeholder="調べたい内容を自然文で入力してください",
                     lines=4,
                     interactive=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                 )
                 self._create_question_examples(question_input)
             with gr.Column(scale=1):
@@ -690,7 +690,7 @@ class UIComponents:
                 label="進捗状況",
                 lines=10,
                 interactive=False,
-                show_copy_button=True,
+                buttons=["copy"],
                 placeholder="質問分解、検索、再検索、選別の流れがここに表示されます",
             )
 
@@ -712,9 +712,9 @@ class UIComponents:
                 with gr.Row():
                     with gr.Column():
                         with gr.Row():
-                            detail_filename_text = gr.Textbox(show_label=True, label="ファイル名", interactive=False, container=True, show_copy_button=True)
-                            detail_image_id_text = gr.Textbox(show_label=True, label="イメージID", interactive=False, container=True, show_copy_button=True)
-                            detail_similarity_text = gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True)
+                            detail_filename_text = gr.Textbox(show_label=True, label="ファイル名", interactive=False, container=True, buttons=["copy"])
+                            detail_image_id_text = gr.Textbox(show_label=True, label="イメージID", interactive=False, container=True, buttons=["copy"])
+                            detail_similarity_text = gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"])
                         with gr.Row():
                             detail_caption_text = gr.Textbox(
                                 show_label=True,
@@ -722,14 +722,14 @@ class UIComponents:
                                 interactive=False,
                                 lines=10,
                                 container=True,
-                                show_copy_button=True,
+                                buttons=["copy"],
                                 placeholder="参照した画像を選択すると詳細がここに表示されます",
                             )
             selection_reason_text = gr.Textbox(
                 label="選別・並べ替え理由",
                 lines=4,
                 interactive=False,
-                show_copy_button=True,
+                buttons=["copy"],
                 placeholder="回答に使用した evidence の選別理由がここに表示されます",
             )
 
@@ -738,7 +738,7 @@ class UIComponents:
                 label="回答",
                 lines=10,
                 interactive=False,
-                show_copy_button=True,
+                buttons=["copy"],
                 placeholder="回答がここに表示されます",
             )
 
@@ -1059,7 +1059,7 @@ class UIComponents:
                         label="現在の回答生成プロンプト",
                         lines=8,
                         interactive=False,
-                        show_copy_button=True,
+                        buttons=["copy"],
                         value=initial_answer_prompt,
                         placeholder="選択された回答生成プロンプトがここに表示されます"
                     )

--- a/app/ui/events.py
+++ b/app/ui/events.py
@@ -698,29 +698,29 @@ class UIEvents:
             # stateの構造を確認
             if state_data is None:
                 print("警告: state_dataがNoneです")
-                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, show_copy_button=True, value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
+                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, buttons=["copy"], value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
                 disabled_radio = gr.Radio(choices=[REFERENCE_TYPE_ALL, REFERENCE_TYPE_CAPTION_ONLY, REFERENCE_TYPE_IMAGE_ONLY], value=REFERENCE_TYPE_ALL, label=REFERENCE_TYPE_LABEL_TEXT, container=True, interactive=False) if reference_type_radio is not None else None
                 
                 if answer_generate_button is not None and reference_image_text is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
                 elif answer_generate_button is not None and reference_image_text is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
                 elif answer_generate_button is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
                 elif answer_generate_button is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button
                 elif reference_image_text is not None and disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
                 elif reference_image_text is not None:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference
                 elif disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_radio
                 else:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None)
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None)
                 
             # state_dataから直接ベクトル検索結果を取得
             vector_results = state_data.get("vector_results", [])
@@ -729,29 +729,29 @@ class UIEvents:
             # インデックスが有効かチェック
             if len(vector_results) <= evt.index:
                 print(f"警告: 無効なインデックス - vector_results長さ={len(vector_results)}, インデックス={evt.index}")
-                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, show_copy_button=True, value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
+                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, buttons=["copy"], value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
                 disabled_radio = gr.Radio(choices=[REFERENCE_TYPE_ALL, REFERENCE_TYPE_CAPTION_ONLY, REFERENCE_TYPE_IMAGE_ONLY], value=REFERENCE_TYPE_ALL, label=REFERENCE_TYPE_LABEL_TEXT, container=True, interactive=False) if reference_type_radio is not None else None
                 
                 if answer_generate_button is not None and reference_image_text is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
                 elif answer_generate_button is not None and reference_image_text is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
                 elif answer_generate_button is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
                 elif answer_generate_button is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button
                 elif reference_image_text is not None and disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
                 elif reference_image_text is not None:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference
                 elif disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_radio
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_radio
                 else:
-                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None)
+                    return "", gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None)
                 
             # ベクトル検索結果を取得
             selected_result = vector_results[evt.index]
@@ -773,7 +773,7 @@ class UIEvents:
             caption = self.search_service.normalize_newlines(selected_result['caption'])
             
             # ベクトル検索の場合はコサイン類似度のラベルで表示
-            similarity_textbox = gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True, value=score_text)
+            similarity_textbox = gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"], value=score_text)
             
             # 参照するドキュメント（画像）の条件判定ロジック
             reference_image_name = ""
@@ -800,7 +800,7 @@ class UIEvents:
                     show_label=True,
                     interactive=False,
                     container=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     value=reference_image_name,
                     placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
                 )
@@ -850,29 +850,29 @@ class UIEvents:
             # state_dataの構造を確認
             if state_data is None:
                 print("警告: state_dataがNoneです")
-                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, show_copy_button=True, value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
+                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, buttons=["copy"], value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
                 disabled_radio = gr.Radio(choices=[REFERENCE_TYPE_ALL, REFERENCE_TYPE_CAPTION_ONLY, REFERENCE_TYPE_IMAGE_ONLY], value=REFERENCE_TYPE_ALL, label=REFERENCE_TYPE_LABEL_TEXT, container=True, interactive=False) if reference_type_radio is not None else None
                 
                 if answer_generate_button is not None and reference_image_text is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
                 elif answer_generate_button is not None and reference_image_text is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
                 elif answer_generate_button is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
                 elif answer_generate_button is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button
                 elif reference_image_text is not None and disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
                 elif reference_image_text is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference
                 elif disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_radio
                 else:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None)
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None)
                 
             # state_dataから直接全文検索結果を取得
             keyword_results = state_data.get("keyword_results", [])
@@ -885,57 +885,57 @@ class UIEvents:
             # 全文検索結果が0件の場合
             if len(keyword_results) == 0:
                 # print("警告: 全文検索結果が0件です")
-                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, show_copy_button=True, value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
+                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, buttons=["copy"], value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
                 disabled_radio = gr.Radio(choices=[REFERENCE_TYPE_ALL, REFERENCE_TYPE_CAPTION_ONLY, REFERENCE_TYPE_IMAGE_ONLY], value=REFERENCE_TYPE_ALL, label=REFERENCE_TYPE_LABEL_TEXT, container=True, interactive=False) if reference_type_radio is not None else None
                 
                 if answer_generate_button is not None and reference_image_text is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
                 elif answer_generate_button is not None and reference_image_text is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
                 elif answer_generate_button is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
                 elif answer_generate_button is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button
                 elif reference_image_text is not None and disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
                 elif reference_image_text is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference
                 elif disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_radio
                 else:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None)
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None)
                 
             # evt.indexが全文検索結果の範囲内かチェック
             if evt.index >= len(keyword_results):
                 print(f"警告: インデックスが範囲外です - インデックス={evt.index}, 結果数={len(keyword_results)}")
                 # インデックスが範囲外の場合はエラーを返す
-                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, show_copy_button=True, value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
+                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, buttons=["copy"], value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
                 disabled_radio = gr.Radio(choices=[REFERENCE_TYPE_ALL, REFERENCE_TYPE_CAPTION_ONLY, REFERENCE_TYPE_IMAGE_ONLY], value=REFERENCE_TYPE_ALL, label=REFERENCE_TYPE_LABEL_TEXT, container=True, interactive=False) if reference_type_radio is not None else None
                 
                 if answer_generate_button is not None and reference_image_text is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
                 elif answer_generate_button is not None and reference_image_text is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
                 elif answer_generate_button is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
                 elif answer_generate_button is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button
                 elif reference_image_text is not None and disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
                 elif reference_image_text is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference
                 elif disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_radio
                 else:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None)
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None)
             
             try:
                 # 選択された全文検索結果を直接取得
@@ -958,7 +958,7 @@ class UIEvents:
                 caption = self.search_service.normalize_newlines(selected_result['caption'])
                 
                 # 全文検索の場合はスコアのラベルで表示
-                similarity_textbox = gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=score_text)
+                similarity_textbox = gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=score_text)
                 
                 # 参照するドキュメント（画像）の条件判定ロジック
                 reference_image_name = ""
@@ -985,7 +985,7 @@ class UIEvents:
                         show_label=True,
                         interactive=False,
                         container=True,
-                        show_copy_button=True,
+                        buttons=["copy"],
                         value=reference_image_name,
                         placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
                     )
@@ -1028,29 +1028,29 @@ class UIEvents:
             except Exception as e:
                 print(f"エラー発生: {str(e)}")
                 # エラーが発生した場合は空の値を返す
-                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, show_copy_button=True, value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
+                empty_reference = gr.Textbox(label=REFERENCE_DOCUMENT_LABEL_TEXT, show_label=True, interactive=False, container=True, buttons=["copy"], value="", placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT) if reference_image_text is not None else None
                 disabled_radio = gr.Radio(choices=[REFERENCE_TYPE_ALL, REFERENCE_TYPE_CAPTION_ONLY, REFERENCE_TYPE_IMAGE_ONLY], value=REFERENCE_TYPE_ALL, label=REFERENCE_TYPE_LABEL_TEXT, container=True, interactive=False) if reference_type_radio is not None else None
                 
                 if answer_generate_button is not None and reference_image_text is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference, disabled_radio
                 elif answer_generate_button is not None and reference_image_text is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, empty_reference
                 elif answer_generate_button is not None and disabled_radio is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button, disabled_radio
                 elif answer_generate_button is not None:
                     disabled_button = gr.Button("回答生成", variant="primary", interactive=False)
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_button
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_button
                 elif reference_image_text is not None and disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference, disabled_radio
                 elif reference_image_text is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), empty_reference
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), empty_reference
                 elif disabled_radio is not None:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None), disabled_radio
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None), disabled_radio
                 else:
-                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True, value=""), "", gr.Gallery(selected_index=None)
+                    return "", gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"], value=""), "", gr.Gallery(selected_index=None)
             
         if reference_image_text is not None and answer_generate_button is not None and reference_type_radio is not None:
             # 参照画像、回答生成ボタン、ラジオボタンも更新する場合
@@ -1222,9 +1222,9 @@ class UIEvents:
     def update_score_label(self, search_method):
         """クエリーの種類に応じてスコアラベルを更新する関数"""
         if search_method == "全文検索":
-            return gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, show_copy_button=True)
+            return gr.Textbox(show_label=True, label="スコア", interactive=False, container=True, buttons=["copy"])
         else:
-            return gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, show_copy_button=True)
+            return gr.Textbox(show_label=True, label="コサイン類似度", interactive=False, container=True, buttons=["copy"])
             
     def update_query_text_interactivity(self, search_method):
         """クエリーの種類に応じてクエリテキストボックスの編集可能性とボタンの表示を切り替える関数"""
@@ -1278,7 +1278,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 container=True,
-                show_copy_button=True,
+                buttons=["copy"],
                 value="",
                 placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
             )
@@ -1289,7 +1289,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 container=True,
-                show_copy_button=True,
+                buttons=["copy"],
                 value="",
                 placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
             )
@@ -1307,7 +1307,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 container=True,
-                show_copy_button=True,
+                buttons=["copy"],
                 value="",
                 placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
             )
@@ -1325,7 +1325,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 container=True,
-                show_copy_button=True,
+                buttons=["copy"],
                 value="",
                 placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
             )
@@ -1449,7 +1449,7 @@ class UIEvents:
                     show_label=True,
                     interactive=False,
                     container=True,
-                    show_copy_button=True,
+                    buttons=["copy"],
                     value="",
                     placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
                 )
@@ -1469,7 +1469,7 @@ class UIEvents:
             show_label=True,
             interactive=False,
             container=True,
-            show_copy_button=True,
+            buttons=["copy"],
             value="",
             placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
         )
@@ -2747,7 +2747,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 lines=16,
-                show_copy_button=True,
+                buttons=["copy"],
                 container=True
             )
         else:
@@ -2757,7 +2757,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 lines=8,
-                show_copy_button=True,
+                buttons=["copy"],
                 container=True
             )
 
@@ -3731,7 +3731,7 @@ class UIEvents:
                 show_label=True,
                 interactive=False,
                 container=True,
-                show_copy_button=True,
+                buttons=["copy"],
                 value=reference_image_name,
                 placeholder=REFERENCE_IMAGE_PLACEHOLDER_TEXT
             )

--- a/multimodal_retriever.py
+++ b/multimodal_retriever.py
@@ -116,7 +116,7 @@ def main():
         overflow-y: auto;
     }
     """
-    with gr.Blocks(title="🐕マルチモーダル・レトリバー🐕", delete_cache=(86400, 86400), css=gallery_scroll_css) as demo:
+    with gr.Blocks(title="🐕マルチモーダル・レトリバー🐕", delete_cache=(86400, 86400)) as demo:
         gr.Markdown("# 🐕マルチモーダル・レトリバー🐕")
         gr.Markdown("画像データベースに自然言語で質問することができます。")
         
@@ -500,6 +500,7 @@ def main():
 
     # アプリケーションの起動
     launch_config = config.get_launch_config()
+    launch_config["css"] = gallery_scroll_css
     demo.launch(**launch_config)
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ oracledb
 pillow
 numpy
 python-dotenv
-gradio
+gradio>=6,<7
 spacy
 ginza
 ja_ginza


### PR DESCRIPTION
…or consistency

- Updated multiple instances in UI components to use 'buttons=["copy"]' instead of 'show_copy_button=True' for better clarity and uniformity.
- Adjusted the main function in `multimodal_retriever.py` to include CSS configuration in the launch settings.
- Enhanced README.md to clarify the output log behavior when using `nohup`.